### PR TITLE
Set the required Ruby version to >= 2.2 in dogwatch.gemspec

### DIFF
--- a/dogwatch.gemspec
+++ b/dogwatch.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.2'
+
   spec.add_runtime_dependency 'dogapi', '~> 1.21'
   spec.add_runtime_dependency 'thor', '~> 0.19'
 end


### PR DESCRIPTION
- This prevents issues with using Ruby 2.0+ exclusive `OpenStruct#each_pair`. (fix #12)
- This prevents issues with using Ruby 2.2+ exclusive syntax. (fix #11)
