### PR TITLE
Update client.rb to change nil options to {}

### DIFF
--- a/lib/dogwatch/model/client.rb
+++ b/lib/dogwatch/model/client.rb
@@ -59,7 +59,7 @@ module DogWatch
           name: monitor.name,
           message: monitor.attributes.message,
           tags: monitor.attributes.tags,
-          options: monitor.attributes.options
+          options: monitor.attributes.options.nil? ? {} : monitor.attributes.options
         }
       end
 


### PR DESCRIPTION
Data sends a "The value provided for parameter 'query' is invalid" if options is not specified. This change checks if options is Nil, if so, it sets options to {}