### PR TITLE
add export to terraform

### DIFF
--- a/bin/dogwatch
+++ b/bin/dogwatch
@@ -30,6 +30,16 @@ module DogWatch
         say_status(*results)
       end
     end
+
+    desc 'create', 'Create a monitor from a Dogfile'
+    def export
+      @dogfile.configure(File.absolute_path(options['dogfile'], @cwd),
+                         options['api_key'], options['app_key'],
+                         options['timeout'])
+      @dogfile.export do |c|
+        print c
+      end
+    end
   end
 end
 

--- a/bin/dogwatch
+++ b/bin/dogwatch
@@ -31,12 +31,22 @@ module DogWatch
       end
     end
 
-    desc 'create', 'Create a monitor from a Dogfile'
+    desc 'export', 'Export a monitor from a Dogfile'
     def export
       @dogfile.configure(File.absolute_path(options['dogfile'], @cwd),
                          options['api_key'], options['app_key'],
                          options['timeout'])
       @dogfile.export do |c|
+        print c
+      end
+    end
+
+    desc 'export_names', 'Export monitor names from a Dogfile'
+    def export_names
+      @dogfile.configure(File.absolute_path(options['dogfile'], @cwd),
+                         options['api_key'], options['app_key'],
+                         options['timeout'])
+      @dogfile.export_names do |c|
         print c
       end
     end

--- a/example/Dogfile
+++ b/example/Dogfile
@@ -5,7 +5,7 @@
 DogWatch.monitor do
   monitor 'test_alert' do
     type :metric_alert
-    query 'avg(last_1dm):avg:system.cpu.user{region:us-east-1} > 20'
+    query 'avg(last_1d):avg:system.cpu.user{region:us-east-1} > 20'
     message 'A message to include with notifications for this monitor.'\
             'Email notifications can be sent to specific users by '\
             'using the same \'@username\' notation as events.'
@@ -35,6 +35,7 @@ DogWatch.monitor do
     options do
       silenced '*': nil
       notify_no_data false
+      notify_audit false
       no_data_timeframe 3
       timeout_h 99
       renotify_interval 60

--- a/lib/dogwatch/dogfile.rb
+++ b/lib/dogwatch/dogfile.rb
@@ -46,9 +46,11 @@ resource "datadog_monitor" "<%= (Digest::SHA256.bubblebabble @monitor.name).gsub
   name               = "<%= variable_ize(@monitor.name) %>"
   type               = "<%= @monitor.attributes.type %>"
   message            = <<EOF
-<%= variable_ize(@monitor.attributes.message) %>"
+<%= variable_ize(@monitor.attributes.message) %>
 EOF
   query = "<%= variable_ize(@monitor.attributes.query) %>"
+  tags = <%= variable_ize(@monitor.attributes.tags.to_s) %>
+  require_full_window = false
   <% if defined?(@monitor.attributes.options) %>
   <% if @monitor.attributes.options[:escalation_message] %>escalation_message = <<EOF
 <%= variable_ize(@monitor.attributes.options[:escalation_message]) %>
@@ -56,29 +58,328 @@ EOF<% end %>
   <% if @monitor.attributes.options[:thresholds] %>thresholds {<% @monitor.attributes.options[:thresholds].each do |k,v| %>
     "<%= k %>": <%= v.to_i %>
     <% end %>}<% end %>
-  <% if @monitor.attributes.options[:notify_no_data] %>notify_no_data    = <%= @monitor.attributes.options[:notify_no_data] %><% end %>
+  notify_no_data    = <% if @monitor.attributes.options[:notify_no_data] %><%= @monitor.attributes.options[:notify_no_data] %><% else %>false<% end %>
   <% if @monitor.attributes.options[:renotify_interval] %>renotify_interval = <%= @monitor.attributes.options[:renotify_interval] %><% end %>
-  <% if @monitor.attributes.options[:notify_audit] %>notify_audit =  <%= @monitor.attributes.options[:notify_audit] %><% end %>
+  notify_audit =  <% if @monitor.attributes.options[:notify_audit] %><%= @monitor.attributes.options[:notify_audit] %><% else %>false<% end %>
   <% if @monitor.attributes.options[:timeout_h] %>timeout_h    = <%= @monitor.attributes.options[:timeout_h] %><% end %>
-  <% if @monitor.attributes.options[:include_tags] %>include_tags = <%= @monitor.attributes.options[:include_tags] %><% end %>
+  include_tags = <% if @monitor.attributes.options[:include_tags] %><%= @monitor.attributes.options[:include_tags] %><% else %>false<% end %>
   <% if @monitor.attributes.options[:silenced] %>silenced {<% @monitor.attributes.options[:silenced].each do |k,v| %>
     "<%= variable_ize(k) %>": <%= v.to_i %>
-    <% end %>}<% end %>
-  <% end %>
+    <% end %>}<% end -%>
+  <% else %>
+  notify_no_data = false
+  notify_audit = false
+  include_tags = false
+  <%= @monitor.attributes.alarm_type %>
+  <%= @monitor.attributes.cluster %>
+  <% end -%>
 
-  tags = <%= variable_ize(@monitor.attributes.tags.to_s) %>
 }
 <% end %>
 }
     end
 
+
+    def get_templates()
+      %{
+<% for @monitor in @monitors %>
+<% if @monitor.attributes.alarm_type == 'cassandra_disk_space_alarms'%>
+module "<%= (Digest::SHA256.bubblebabble @monitor.name).gsub('-', '_') %>" {
+  source = "cassandra_disk_space_alarms"
+  region = "${var.region}"
+  threshold = <%= @monitor.attributes.threshold %>
+  cluster = "<%= @monitor.attributes.cluster %>"
+  stack = "${var.stack}"
+  duration = "<%= @monitor.attributes.duration %>"
+  team = "<%= @monitor.attributes.team %>"
+<% if defined?(@monitor.attributes.options) %>
+  notify_no_data = <% if @monitor.attributes.options[:notify_no_data] %><%= @monitor.attributes.options[:notify_no_data] %><% else %>false<% end %>
+  notify_audit = <% if @monitor.attributes.options[:notify_audit] %><%= @monitor.attributes.options[:notify_audit] %><% else %>false<% end %>
+  include_tags = <% if @monitor.attributes.options[:include_tags] %><%= @monitor.attributes.options[:include_tags] %><% else %>false<% end %>
+<% end %>
+}
+<% elsif @monitor.attributes.alarm_type == 'cassandra_read_alarms'%>
+module "<%= (Digest::SHA256.bubblebabble @monitor.name).gsub('-', '_') %>" {
+  source = "cassandra_read_alarms"
+  region = "${var.region}"
+  threshold = <%= @monitor.attributes.threshold %>
+  cluster = "<%= @monitor.attributes.cluster %>"
+  stack = "${var.stack}"
+  <% if @monitor.attributes.duration %>duration = "<%= @monitor.attributes.duration %>"<% end -%>
+  time_window = "<%= @monitor.attributes.time_window %>"
+  time_shift = "<%= @monitor.attributes.time_shift %>"
+  team = "${var.team}"
+}
+<% elsif @monitor.attributes.alarm_type == 'cassandra_write_alarms'%>
+module "<%= (Digest::SHA256.bubblebabble @monitor.name).gsub('-', '_') %>" {
+  source = "cassandra_write_alarms"
+  region = "${var.region}"
+  threshold = <%= @monitor.attributes.threshold %>
+  cluster = "<%= @monitor.attributes.cluster %>"
+  stack = "${var.stack}"
+  <% if @monitor.attributes.duration %>duration = "<%= @monitor.attributes.duration %>"<% end -%>
+  time_window = "<%= @monitor.attributes.time_window %>"
+  time_shift = "<%= @monitor.attributes.time_shift %>"
+  team = "${var.team}"
+}
+<% elsif @monitor.attributes.alarm_type == 'cassandra_memory_alarms'%>
+module "<%= (Digest::SHA256.bubblebabble @monitor.name).gsub('-', '_') %>" {
+  source = "cassandra_memory_alarms"
+  region = "${var.region}"
+  threshold = <%= @monitor.attributes.threshold %>
+  cluster = "<%= @monitor.attributes.cluster %>"
+  stack = "${var.stack}"
+  duration = "<%= @monitor.attributes.duration %>"
+  team = "<%= @monitor.attributes.team %>"
+<% if defined?(@monitor.attributes.options) %>
+  notify_no_data = <% if @monitor.attributes.options[:notify_no_data] %><%= @monitor.attributes.options[:notify_no_data] %><% else %>false<% end %>
+  notify_audit = <% if @monitor.attributes.options[:notify_audit] %><%= @monitor.attributes.options[:notify_audit] %><% else %>false<% end %>
+  include_tags = <% if @monitor.attributes.options[:include_tags] %><%= @monitor.attributes.options[:include_tags] %><% else %>false<% end %>
+<% end %>
+}
+<% elsif @monitor.attributes.alarm_type == 'unknown_exceptions_alarms'%>
+module "<%= (Digest::SHA256.bubblebabble @monitor.name).gsub('-', '_') %>" {
+  source = "unknown_exceptions_alarms"
+  region = "${var.region}"
+  threshold = <%= @monitor.attributes.threshold %>
+  duration = "<%= @monitor.attributes.duration %>"
+  service_name = "<%= @monitor.attributes.service_name %>"
+  stack = "${var.stack}"
+  team = "<%= @monitor.attributes.team %>"
+  team_notify = "<%= @monitor.attributes.team_notify %>"
+<% if defined?(@monitor.attributes.options) %>
+  notify_no_data = <% if @monitor.attributes.options[:notify_no_data] %><%= @monitor.attributes.options[:notify_no_data] %><% else %>false<% end %>
+  notify_audit = <% if @monitor.attributes.options[:notify_audit] %><%= @monitor.attributes.options[:notify_audit] %><% else %>false<% end %>
+  include_tags = <% if @monitor.attributes.options[:include_tags] %><%= @monitor.attributes.options[:include_tags] %><% else %>false<% end %>
+<% end %>
+}
+<% elsif @monitor.attributes.alarm_type == 'known_exceptions_alarms'%>
+module "<%= (Digest::SHA256.bubblebabble @monitor.name).gsub('-', '_') %>" {
+  source = "known_exceptions_alarms"
+  region = "${var.region}"
+  threshold = <%= @monitor.attributes.threshold %>
+  duration = "<%= @monitor.attributes.duration %>"
+  service_name = "<%= @monitor.attributes.service_name %>"
+  stack = "${var.stack}"
+  team = "<%= @monitor.attributes.team %>"
+  team_notify = "<%= @monitor.attributes.team_notify %>"
+<% if defined?(@monitor.attributes.options) %>
+  notify_no_data = <% if @monitor.attributes.options[:notify_no_data] %><%= @monitor.attributes.options[:notify_no_data] %><% else %>false<% end %>
+  notify_audit = <% if @monitor.attributes.options[:notify_audit] %><%= @monitor.attributes.options[:notify_audit] %><% else %>false<% end %>
+  include_tags = <% if @monitor.attributes.options[:include_tags] %><%= @monitor.attributes.options[:include_tags] %><% else %>false<% end %>
+<% end %>
+}
+<% elsif @monitor.attributes.alarm_type == 'hystrix_alarms'%>
+module "<%= (Digest::SHA256.bubblebabble @monitor.name).gsub('-', '_') %>" {
+  source = "hystrix_alarms"
+  region = "${var.region}"
+  threshold = <%= @monitor.attributes.threshold %>
+  stack = "${var.stack}"
+  duration = "<%= @monitor.attributes.duration %>"
+  team = "<%= @monitor.attributes.team %>"
+  consumer_service_name = "<%= @monitor.attributes.consumer_service_name %>"
+  upstream_service_name = "<%= @monitor.attributes.upstream_service_name %>"
+  team_notify = "<%= @monitor.attributes.team_notify %>"
+<% if defined?(@monitor.attributes.options) %>
+  notify_no_data = <% if @monitor.attributes.options[:notify_no_data] %><%= @monitor.attributes.options[:notify_no_data] %><% else %>false<% end %>
+  notify_audit = <% if @monitor.attributes.options[:notify_audit] %><%= @monitor.attributes.options[:notify_audit] %><% else %>false<% end %>
+  include_tags = <% if @monitor.attributes.options[:include_tags] %><%= @monitor.attributes.options[:include_tags] %><% else %>false<% end %>
+<% end %>
+}
+<% elsif @monitor.attributes.alarm_type == 'rds_cpu_alarms' || @monitor.attributes.alarm_type == 'rds_replica_lag_alarms' || @monitor.attributes.alarm_type == 'rds_disk_space_alarms' || @monitor.attributes.alarm_type == 'rds_connection_count_alarms' %>
+module "<%= (Digest::SHA256.bubblebabble @monitor.name).gsub('-', '_') %>" {
+  source = "<%= @monitor.attributes.alarm_type %>"
+  region = "${var.region}"
+  stack = "${var.stack}"
+  duration = "<%= @monitor.attributes.duration %>"
+  team = "<%= @monitor.attributes.team %>"
+  severity = "<%= @monitor.attributes.severity %>"
+  notify_threshold = "<%= @monitor.attributes.notify_threshold %>"
+  service_name = "<%= @monitor.attributes.service_name %>"
+  host = "<%= @monitor.attributes.host %>"
+<% if defined?(@monitor.attributes.options) %>
+  notify_no_data = <% if @monitor.attributes.options[:notify_no_data] %><%= @monitor.attributes.options[:notify_no_data] %><% else %>false<% end %>
+  notify_audit = <% if @monitor.attributes.options[:notify_audit] %><%= @monitor.attributes.options[:notify_audit] %><% else %>false<% end %>
+  include_tags = <% if @monitor.attributes.options[:include_tags] %><%= @monitor.attributes.options[:include_tags] %><% else %>false<% end %>
+<% end %>
+}
+<% elsif @monitor.attributes.alarm_type == 'redis_memory_alarms' || @monitor.attributes.alarm_type == 'redis_cpu_alarms' %>
+module "<%= (Digest::SHA256.bubblebabble @monitor.name).gsub('-', '_') %>" {
+  source = "<%= @monitor.attributes.alarm_type %>"
+  region = "${var.region}"
+  threshold = <%= @monitor.attributes.threshold %>
+  stack = "${var.stack}"
+  duration = "<%= @monitor.attributes.duration %>"
+  team = "<%= @monitor.attributes.team %>"
+  node_type = "<%= @monitor.attributes.node_type %>"
+  service_name = "<%= @monitor.attributes.service_name %>"
+  cluster_id = "<%= @monitor.attributes.cluster_id %>"
+  team_notify = "<%= @monitor.attributes.team_notify %>"
+<% if defined?(@monitor.attributes.options) %>
+  notify_no_data = <% if @monitor.attributes.options[:notify_no_data] %><%= @monitor.attributes.options[:notify_no_data] %><% else %>false<% end %>
+  notify_audit = <% if @monitor.attributes.options[:notify_audit] %><%= @monitor.attributes.options[:notify_audit] %><% else %>false<% end %>
+  include_tags = <% if @monitor.attributes.options[:include_tags] %><%= @monitor.attributes.options[:include_tags] %><% else %>false<% end %>
+<% end %>
+}
+<% elsif @monitor.attributes.alarm_type == 'sqs_low_publish_rate_alarms' %>
+module "<%= (Digest::SHA256.bubblebabble @monitor.name).gsub('-', '_') %>" {
+  source = "<%= @monitor.attributes.alarm_type %>"
+  region = "${var.region}"
+  stack = "${var.stack}"
+  duration = "<%= @monitor.attributes.duration %>"
+  team = "<%= @monitor.attributes.team %>"
+  notify_threshold = "<%= @monitor.attributes.notify_threshold %>"
+  service_tag = "<%= @monitor.attributes.service_tag %>"
+  payload_type = "<%= @monitor.attributes.payload_type %>"
+  payload_subtype = "<%= @monitor.attributes.payload_subtype %>"
+  service_name = "<%= @monitor.attributes.service_name %>"
+  team_notify = "<%= @monitor.attributes.team_notify %>"
+<% if defined?(@monitor.attributes.options) %>
+  <% if @monitor.attributes.options[:renotify_interval] %>renotify_interval = <%= @monitor.attributes.options[:renotify_interval] %><% end %>
+<% end %>
+}
+<% elsif @monitor.attributes.alarm_type == 'sqs_queue_backup_alarms_low_urgency' %>
+module "<%= (Digest::SHA256.bubblebabble @monitor.name).gsub('-', '_') %>" {
+  source = "<%= @monitor.attributes.alarm_type %>"
+  region = "${var.region}"
+  stack = "${var.stack}"
+  duration = "<%= @monitor.attributes.duration %>"
+  team = "<%= @monitor.attributes.team %>"
+  notify_threshold = "<%= @monitor.attributes.notify_threshold %>"
+  service_tag = "<%= @monitor.attributes.service_tag %>"
+  payload_type = "<%= @monitor.attributes.payload_type %>"
+  payload_subtype = "<%= @monitor.attributes.payload_subtype %>"
+  service_name = "<%= @monitor.attributes.service_name %>"
+  team_notify = "<%= @monitor.attributes.team_notify %>"
+  low_urgency_threshold = "<%= @monitor.attributes.low_urgency_threshold %>"
+<% if defined?(@monitor.attributes.options) %>
+  <% if @monitor.attributes.options[:renotify_interval] %>renotify_interval = <%= @monitor.attributes.options[:renotify_interval] %><% end %>
+<% end %>
+}
+<% elsif @monitor.attributes.alarm_type == 'sqs_queue_backup_alarms_high_urgency' %>
+module "<%= (Digest::SHA256.bubblebabble @monitor.name).gsub('-', '_') %>" {
+  source = "<%= @monitor.attributes.alarm_type %>"
+  region = "${var.region}"
+  stack = "${var.stack}"
+  duration = "<%= @monitor.attributes.duration %>"
+  team = "<%= @monitor.attributes.team %>"
+  notify_threshold = "<%= @monitor.attributes.notify_threshold %>"
+  service_tag = "<%= @monitor.attributes.service_tag %>"
+  payload_type = "<%= @monitor.attributes.payload_type %>"
+  payload_subtype = "<%= @monitor.attributes.payload_subtype %>"
+  service_name = "<%= @monitor.attributes.service_name %>"
+  team_notify = "<%= @monitor.attributes.team_notify %>"
+  high_urgency_threshold = "<%= @monitor.attributes.high_urgency_threshold %>"
+<% if defined?(@monitor.attributes.options) %>
+  <% if @monitor.attributes.options[:renotify_interval] %>renotify_interval = <%= @monitor.attributes.options[:renotify_interval] %><% end %>
+<% end %>
+}
+<% elsif @monitor.attributes.alarm_type == 'sqs_retry_queue_backup_alarms_high_urgency' %>
+module "<%= (Digest::SHA256.bubblebabble @monitor.name).gsub('-', '_') %>" {
+  source = "<%= @monitor.attributes.alarm_type %>"
+  region = "${var.region}"
+  stack = "${var.stack}"
+  duration = "<%= @monitor.attributes.duration %>"
+  team = "<%= @monitor.attributes.team %>"
+  notify_threshold = "<%= @monitor.attributes.notify_threshold %>"
+  service_tag = "<%= @monitor.attributes.service_tag %>"
+  payload_type = "<%= @monitor.attributes.payload_type %>"
+  payload_subtype = "<%= @monitor.attributes.payload_subtype %>"
+  service_name = "<%= @monitor.attributes.service_name %>"
+  team_notify = "<%= @monitor.attributes.team_notify %>"
+  high_urgency_threshold = "<%= @monitor.attributes.high_urgency_threshold %>"
+<% if defined?(@monitor.attributes.options) %>
+  <% if @monitor.attributes.options[:renotify_interval] %>renotify_interval = <%= @monitor.attributes.options[:renotify_interval] %><% end %>
+<% end %>
+}
+<% elsif @monitor.attributes.alarm_type == 'sqs_retry_queue_backup_alarms_low_urgency' %>
+module "<%= (Digest::SHA256.bubblebabble @monitor.name).gsub('-', '_') %>" {
+  source = "<%= @monitor.attributes.alarm_type %>"
+  region = "${var.region}"
+  stack = "${var.stack}"
+  duration = "<%= @monitor.attributes.duration %>"
+  team = "<%= @monitor.attributes.team %>"
+  notify_threshold = "<%= @monitor.attributes.notify_threshold %>"
+  service_tag = "<%= @monitor.attributes.service_tag %>"
+  payload_type = "<%= @monitor.attributes.payload_type %>"
+  payload_subtype = "<%= @monitor.attributes.payload_subtype %>"
+  service_name = "<%= @monitor.attributes.service_name %>"
+  team_notify = "<%= @monitor.attributes.team_notify %>"
+  low_urgency_threshold = "<%= @monitor.attributes.low_urgency_threshold %>"
+<% if defined?(@monitor.attributes.options) %>
+  <% if @monitor.attributes.options[:renotify_interval] %>renotify_interval = <%= @monitor.attributes.options[:renotify_interval] %><% end %>
+<% end %>
+}
+<% elsif @monitor.attributes.alarm_type == 'sqs_payload_giveup_alarms' %>
+module "<%= (Digest::SHA256.bubblebabble @monitor.name).gsub('-', '_') %>" {
+  source = "<%= @monitor.attributes.alarm_type %>"
+  region = "${var.region}"
+  threshold = <%= @monitor.attributes.threshold %>
+  stack = "${var.stack}"
+  duration = "<%= @monitor.attributes.duration %>"
+  team = "<%= @monitor.attributes.team %>"
+  notify_threshold = "<%= @monitor.attributes.notify_threshold %>"
+  service_tag = "<%= @monitor.attributes.service_tag %>"
+  payload_type = "<%= @monitor.attributes.payload_type %>"
+  payload_subtype = "<%= @monitor.attributes.payload_subtype %>"
+  service_name = "<%= @monitor.attributes.service_name %>"
+  team_notify = "<%= @monitor.attributes.team_notify %>"
+}
+<% elsif @monitor.attributes.alarm_type != 'NONE'%>
+resource "datadog_monitor" "<%= (Digest::SHA256.bubblebabble @monitor.name).gsub('-', '_') %>" {
+  name               = "<%= variable_ize(@monitor.name) %>"
+  type               = "<%= @monitor.attributes.type %>"
+  message            = <<EOF
+<%= variable_ize(@monitor.attributes.message) %>
+EOF
+  query = "<%= variable_ize(@monitor.attributes.query) %>"
+  tags = <%= variable_ize(@monitor.attributes.tags.to_s) %>
+  require_full_window = false
+  <% if defined?(@monitor.attributes.options) %>
+  <% if @monitor.attributes.options[:escalation_message] %>escalation_message = <<EOF
+<%= variable_ize(@monitor.attributes.options[:escalation_message]) %>
+EOF<% end %>
+  <% if @monitor.attributes.options[:thresholds] %>thresholds {<% @monitor.attributes.options[:thresholds].each do |k,v| %>
+    "<%= k %>": <%= v.to_i %>
+    <% end %>}<% end %>
+  notify_no_data    = <% if @monitor.attributes.options[:notify_no_data] %><%= @monitor.attributes.options[:notify_no_data] %><% else %>false<% end %>
+  <% if @monitor.attributes.options[:renotify_interval] %>renotify_interval = <%= @monitor.attributes.options[:renotify_interval] %><% end %>
+  notify_audit =  <% if @monitor.attributes.options[:notify_audit] %><%= @monitor.attributes.options[:notify_audit] %><% else %>false<% end %>
+  <% if @monitor.attributes.options[:timeout_h] %>timeout_h    = <%= @monitor.attributes.options[:timeout_h] %><% end %>
+  include_tags = <% if @monitor.attributes.options[:include_tags] %><%= @monitor.attributes.options[:include_tags] %><% else %>false<% end %>
+  <% if @monitor.attributes.options[:silenced] %>silenced {<% @monitor.attributes.options[:silenced].each do |k,v| %>
+    "<%= variable_ize(k) %>": <%= v.to_i %>
+    <% end %>}<% end -%>
+  <% else %>
+  notify_no_data = false
+  notify_audit = false
+  include_tags = false
+  <% end -%>
+}
+<% end %>
+<% end %>
+}
+
+    end
     def export
       monitor = instance_eval(IO.read(@dogfile), @dogfile, 1)
       if monitor.is_a?(DogWatch::Monitor)
-        print ERB.new(get_template).result(monitor.get_binding)
+        print ERB.new(get_templates, nil, '-').result(monitor.get_binding)
       else
         print 'Unexpected file content!'
       end
     end
+
+    def export_names
+      monitor = instance_eval(IO.read(@dogfile), @dogfile, 1)
+      if monitor.is_a?(DogWatch::Monitor)
+        monitor.monitors.each {|m|
+          printf "%s\t%s\n",  Digest::SHA256.bubblebabble(m.name.gsub('razor-prod-0', '${var.stack}').gsub('eu-central-1', '${var.region}')).gsub('-', '_'), CGI::escape(m.name)
+        }
+      else
+        print 'Unexpected file content!'
+      end
+    end
+
   end
 end

--- a/lib/dogwatch/dogfile.rb
+++ b/lib/dogwatch/dogfile.rb
@@ -1,3 +1,6 @@
+require 'erb'
+require 'digest/bubblebabble'
+
 require_relative 'model/config'
 require_relative 'model/client'
 
@@ -33,6 +36,48 @@ module DogWatch
         end
 
         block.call(klass.new)
+      end
+    end
+
+    def get_template()
+%{
+<% for @monitor in @monitors %>
+resource "datadog_monitor" "<%= (Digest::SHA256.bubblebabble @monitor.name).gsub('-', '_') %>" {
+  name               = "<%= variable_ize(@monitor.name) %>"
+  type               = "<%= @monitor.attributes.type %>"
+  message            = <<EOF
+<%= variable_ize(@monitor.attributes.message) %>"
+EOF
+  query = "<%= variable_ize(@monitor.attributes.query) %>"
+  <% if defined?(@monitor.attributes.options) %>
+  <% if @monitor.attributes.options[:escalation_message] %>escalation_message = <<EOF
+<%= variable_ize(@monitor.attributes.options[:escalation_message]) %>
+EOF<% end %>
+  <% if @monitor.attributes.options[:thresholds] %>thresholds {<% @monitor.attributes.options[:thresholds].each do |k,v| %>
+    "<%= k %>": <%= v.to_i %>
+    <% end %>}<% end %>
+  <% if @monitor.attributes.options[:notify_no_data] %>notify_no_data    = <%= @monitor.attributes.options[:notify_no_data] %><% end %>
+  <% if @monitor.attributes.options[:renotify_interval] %>renotify_interval = <%= @monitor.attributes.options[:renotify_interval] %><% end %>
+  <% if @monitor.attributes.options[:notify_audit] %>notify_audit =  <%= @monitor.attributes.options[:notify_audit] %><% end %>
+  <% if @monitor.attributes.options[:timeout_h] %>timeout_h    = <%= @monitor.attributes.options[:timeout_h] %><% end %>
+  <% if @monitor.attributes.options[:include_tags] %>include_tags = <%= @monitor.attributes.options[:include_tags] %><% end %>
+  <% if @monitor.attributes.options[:silenced] %>silenced {<% @monitor.attributes.options[:silenced].each do |k,v| %>
+    "<%= variable_ize(k) %>": <%= v.to_i %>
+    <% end %>}<% end %>
+  <% end %>
+
+  tags = <%= variable_ize(@monitor.attributes.tags.to_s) %>
+}
+<% end %>
+}
+    end
+
+    def export
+      monitor = instance_eval(IO.read(@dogfile), @dogfile, 1)
+      if monitor.is_a?(DogWatch::Monitor)
+        print ERB.new(get_template).result(monitor.get_binding)
+      else
+        print 'Unexpected file content!'
       end
     end
   end

--- a/lib/dogwatch/model/monitor.rb
+++ b/lib/dogwatch/model/monitor.rb
@@ -42,10 +42,172 @@ module DogWatch
         @attributes.message = message.to_s
       end
 
+      # @param [String] alarm_type
+      # @return [String]
+      def alarm_type(alarm_type)
+        @attributes.alarm_type = alarm_type.to_s
+      end
+
+      # @param [String] duration
+      # @return [String]
+      def duration(duration)
+        @attributes.duration = duration.to_s
+      end
+
+      # @param [String] threshold
+      # @return [String]
+      def threshold(threshold)
+        @attributes.threshold = threshold.to_s
+      end
+
+      # @param [String] team
+      # @return [String]
+      def team(team)
+        @attributes.team = team.to_s
+      end
+
+      # @param [String] cluster
+      # @return [String]
+      def cluster(cluster)
+        @attributes.cluster = cluster.to_s
+      end
+
+      # @param [String] time_shift
+      # @return [String]
+      def time_shift(time_shift)
+        @attributes.time_shift = time_shift.to_s
+      end
+
+      # @param [String] time_window
+      # @return [String]
+      def time_window(time_window)
+        @attributes.time_window = time_window.to_s
+      end
+
       # @param [Array] tags
       # @return [Array]
       def tags(tags)
         @attributes.tags = tags.to_a
+      end
+
+      # @param [Array] region
+      # @return [Array]
+      def region(region=nil)
+        @attributes.region = region.to_s
+      end
+
+      # @param [Array] stack
+      # @return [Array]
+      def stack(stack)
+        @attributes.stack = stack.to_s
+      end
+
+      # @param [Array] service_name
+      # @return [Array]
+      def service_name(service_name)
+        @attributes.service_name = service_name.to_s
+      end
+
+      # @param [Array] payload_type
+      # @return [Array]
+      def payload_type(payload_type)
+        @attributes.payload_type = payload_type.to_s
+      end
+
+      # @param [Array] payload_subtype
+      # @return [Array]
+      def payload_subtype(payload_subtype)
+        @attributes.payload_subtype = payload_subtype.to_s
+      end
+
+      # @param [Array] service_tag
+      # @return [Array]
+      def service_tag(service_tag)
+        @attributes.service_tag = service_tag.to_s
+      end
+
+      # @param [Array] team_notify
+      # @return [Array]
+      def team_notify(team_notify)
+        @attributes.team_notify = team_notify.to_s
+      end
+
+      # @param [Array] queue
+      # @return [Array]
+      def queue(queue)
+        @attributes.queue = queue.to_s
+      end
+
+      # @param [Array] low_urgency_threshold
+      # @return [Array]
+      def low_urgency_threshold(low_urgency_threshold)
+        @attributes.low_urgency_threshold = low_urgency_threshold.to_s
+      end
+
+      # @param [Array] high_urgency_threshold
+      # @return [Array]
+      def high_urgency_threshold(high_urgency_threshold)
+        @attributes.high_urgency_threshold = high_urgency_threshold.to_s
+      end
+
+      # @param [Array] team_low_urgency_notify
+      # @return [Array]
+      def team_low_urgency_notify(team_low_urgency_notify)
+        @attributes.team_low_urgency_notify = team_low_urgency_notify.to_s
+      end
+
+      # @param [Array] team_high_urgency_notify
+      # @return [Array]
+      def team_high_urgency_notify(team_high_urgency_notify)
+        @attributes.team_high_urgency_notify = team_high_urgency_notify.to_s
+      end
+
+      # @param [Array] notify_threshold
+      # @return [Array]
+      def notify_threshold(notify_threshold)
+        @attributes.notify_threshold = notify_threshold.to_s
+      end
+
+      # @param [Array] severity
+      # @return [Array]
+      def severity(severity)
+        @attributes.severity = severity.to_s
+      end
+
+      # @param [Array] notify
+      # @return [Array]
+      def notify(notify)
+        @attributes.notify = notify.to_s
+      end
+
+      # @param [Array] consumer_service_name
+      # @return [Array]
+      def consumer_service_name(consumer_service_name)
+        @attributes.consumer_service_name = consumer_service_name.to_s
+      end
+
+      # @param [Array] host
+      # @return [Array]
+      def host(host)
+        @attributes.host = host.to_s
+      end
+
+      # @param [Array] upstream_service_name
+      # @return [Array]
+      def upstream_service_name(upstream_service_name)
+        @attributes.upstream_service_name = upstream_service_name.to_s
+      end
+
+      # @param [Array] cluster_id
+      # @return [Array]
+      def cluster_id(cluster_id)
+        @attributes.cluster_id = cluster_id.to_s
+      end
+
+      # @param [Array] node_type
+      # @return [Array]
+      def node_type(node_type)
+        @attributes.node_type = node_type.to_s
       end
 
       # @param [Proc] block

--- a/lib/dogwatch/monitor.rb
+++ b/lib/dogwatch/monitor.rb
@@ -49,5 +49,15 @@ module DogWatch
                   client
                 end
     end
+
+    def variable_ize(str)
+      str.gsub('eu-central-1', '${var.region}')
+          .gsub('razor-prod-0', '${var.stack}')
+    end
+
+    # Expose private binding() method.
+    def get_binding
+      binding()
+    end
   end
 end

--- a/lib/dogwatch/monitor.rb
+++ b/lib/dogwatch/monitor.rb
@@ -29,6 +29,11 @@ module DogWatch
       @monitors << monitor
     end
 
+    def monitors()
+      @monitors
+    end
+
+
     # @return [Array]
     def get
       @responses = @monitors.map do |m|


### PR DESCRIPTION
This should NOT be merged!

This extends dogwatch so that it prints out monitors in terraform format.

This is not generic and is meant to work hand in hand with https://github.com/rapid7/razor-dogwatch/pull/230